### PR TITLE
Refactoring the GigaCache underlying architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/xgzlucario/GigaCache)](https://goreportcard.com/report/github.com/xgzlucario/GigaCache) [![Go Reference](https://pkg.go.dev/badge/github.com/xgzlucario/GigaCache.svg)](https://pkg.go.dev/github.com/xgzlucario/GigaCache) ![](https://img.shields.io/badge/go-1.21.0-orange.svg) ![](https://img.shields.io/github/languages/code-size/xgzlucario/GigaCache.svg) [![codecov](https://codecov.io/gh/xgzlucario/GigaCache/graph/badge.svg?token=yC1xELYaM2)](https://codecov.io/gh/xgzlucario/GigaCache) [![Test and coverage](https://github.com/xgzlucario/GigaCache/actions/workflows/rotom.yml/badge.svg)](https://github.com/xgzlucario/GigaCache/actions/workflows/rotom.yml)
 
-Powerful, fast, eviction supported cache for managing Gigabytes of data, multi-threads support, faster than golang stdmap.
+Powerful, fast, eviction supported cache for managing Gigabytes of data, multi-threads support, Set() method is 2x fast as `built-in map`.
 
 [See doc here](https://www.yuque.com/1ucario/devdoc/ntyyeekkxu8apngd?singleDoc)
 
@@ -64,27 +64,27 @@ cpu: 13th Gen Intel(R) Core(TM) i5-13600KF
 
 Gigache Set operation has better performance than stdmap.
 
-| Benchmark           | Iter    | time/op     | bytes/op | alloc/op    |
-| ------------------- | ------- | ----------- | -------- | ----------- |
-| Set/stdmap-20       | 4059187 | 315.2 ns/op | 156 B/op | 1 allocs/op |
-| Set/gigacache-20    | 4897693 | 277.9 ns/op | 133 B/op | 1 allocs/op |
-| Set/gigacache/Tx-20 | 4355415 | 328.2 ns/op | 161 B/op | 1 allocs/op |
+| Benchmark        | Iter    | time/op     | bytes/op | alloc/op    |
+| ---------------- | ------- | ----------- | -------- | ----------- |
+| Set/stdmap-20    | 3864405 | 335.9 ns/op | 210 B/op | 1 allocs/op |
+| Set/GigaCache-20 | 7264236 | 227.4 ns/op | 173 B/op | 2 allocs/op |
+| Set/swissmap-20  | 6519584 | 212.5 ns/op | 113 B/op | 0 allocs/op |
 
 **Get** from 100k entries.
 
-| Benchmark           | Iter    | time/op     | bytes/op | alloc/op    |
-| ------------------- | ------- | ----------- | -------- | ----------- |
-| Get/stdmap-20       | 8906018 | 150.1 ns/op | 7 B/op   | 0 allocs/op |
-| Get/gigacache-20    | 7293346 | 167.1 ns/op | 7 B/op   | 0 allocs/op |
-| Get/gigacache/Tx-20 | 5621548 | 204.0 ns/op | 7 B/op   | 0 allocs/op |
+| Benchmark        | Iter     | time/op     | bytes/op | alloc/op    |
+| ---------------- | -------- | ----------- | -------- | ----------- |
+| Get/stdmap-20    | 47223234 | 26.28 ns/op | 7 B/op   | 0 allocs/op |
+| Get/GigaCache-20 | 26522108 | 42.99 ns/op | 8 B/op   | 0 allocs/op |
+| Get/swissmap-20  | 46438924 | 26.10 ns/op | 7 B/op   | 0 allocs/op |
 
 **Delete**
 
 | Benchmark              | Iter     | time/op     | bytes/op | alloc/op    |
 | ---------------------- | -------- | ----------- | -------- | ----------- |
-| Delete/stdmap-20       | 70440334 | 16.38 ns/op |	7 B/op	 | 0 allocs/op |
-| Delete/gigacache-20    | 24050403 | 48.55 ns/op |	8 B/op	 | 1 allocs/op |
-| Delete/gigacache/Ex-20 | 22860742	| 50.32 ns/op |	9 B/op	 | 1 allocs/op |
+| Delete/stdmap-20       | 87499602 | 14.53 ns/op |	7 B/op	 | 0 allocs/op |
+| Delete/GigaCache-20 | 22143832 | 49.78 ns/op |	8 B/op	 | 1 allocs/op |
+| Delete/swissmap-20 | 50007508	| 24.14 ns/op |	7 B/op	| 0 allocs/op |
 
 **GC pause time**（Reference to [allegro/bigcache-bench](https://github.com/allegro/bigcache-bench)）
 

--- a/cache.go
+++ b/cache.go
@@ -143,11 +143,12 @@ func (c *GigaCache) Has(kstr string) bool {
 func (c *GigaCache) Get(kstr string) (any, int64, bool) {
 	b, key := c.getShard(kstr)
 	b.RLock()
-	defer b.RUnlock()
 	if v, ok := b.idx.Get(key); ok {
 		_, val, ts, ok := b.find(key, v)
+		b.RUnlock()
 		return val, ts, ok
 	}
+	b.RUnlock()
 	return nil, 0, false
 }
 

--- a/cache.go
+++ b/cache.go
@@ -114,7 +114,7 @@ func (b *bucket) find(k Key, v V, nocopy ...bool) (string, any, int64, bool) {
 		bytes := getSlice(b.bytes, v.start()+k.klen(), v.offset())
 
 		// nocopy
-		if nocopy != nil && nocopy[0] {
+		if len(nocopy) > 0 && nocopy[0] {
 			return *b2s(kstr), bytes, v.TTL, true
 		}
 		return string(kstr), slices.Clone(bytes), v.TTL, true

--- a/cache_bench_test.go
+++ b/cache_bench_test.go
@@ -1,13 +1,10 @@
 package cache
 
 import (
-	"math/rand"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/dolthub/swiss"
-	rand2 "golang.org/x/exp/rand"
 )
 
 func getStdmap() map[string][]byte {
@@ -26,21 +23,14 @@ func BenchmarkSet(b *testing.B) {
 		}
 	})
 
-	b.Run("gigacache", func(b *testing.B) {
+	b.Run("GigaCache", func(b *testing.B) {
 		m := New()
 		for i := 0; i < b.N; i++ {
 			m.Set(strconv.Itoa(i), str)
 		}
 	})
 
-	b.Run("gigacache/Ex", func(b *testing.B) {
-		m := New()
-		for i := 0; i < b.N; i++ {
-			m.SetEx(strconv.Itoa(i), str, time.Minute)
-		}
-	})
-
-	b.Run("swiss/map", func(b *testing.B) {
+	b.Run("swissmap", func(b *testing.B) {
 		m := swiss.NewMap[string, []byte](8)
 		for i := 0; i < b.N; i++ {
 			m.Put(strconv.Itoa(i), str)
@@ -56,23 +46,23 @@ func BenchmarkGet(b *testing.B) {
 		}
 	})
 
-	m3 := New()
+	m2 := New()
 	for i := 0; i < num; i++ {
-		m3.Set(strconv.Itoa(i), str)
+		m2.Set(strconv.Itoa(i), str)
 	}
-	b.Run("gigacache", func(b *testing.B) {
+	b.Run("GigaCache", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			m3.Get(strconv.Itoa(i))
+			m2.Get(strconv.Itoa(i))
 		}
 	})
 
-	m4 := New()
+	m3 := swiss.NewMap[string, []byte](8)
 	for i := 0; i < num; i++ {
-		m4.SetEx(strconv.Itoa(i), str, time.Minute)
+		m3.Put(strconv.Itoa(i), str)
 	}
-	b.Run("gigacache/Ex", func(b *testing.B) {
+	b.Run("swissmap", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			m4.Get(strconv.Itoa(i))
+			m3.Get(strconv.Itoa(i))
 		}
 	})
 }
@@ -87,7 +77,7 @@ func BenchmarkDelete(b *testing.B) {
 		}
 	})
 
-	b.Run("gigacache", func(b *testing.B) {
+	b.Run("GigaCache", func(b *testing.B) {
 		m := New()
 		for i := 0; i < num; i++ {
 			m.Set(strconv.Itoa(i), str)
@@ -99,30 +89,15 @@ func BenchmarkDelete(b *testing.B) {
 		}
 	})
 
-	b.Run("gigacache/Ex", func(b *testing.B) {
-		m := New()
+	b.Run("swissmap", func(b *testing.B) {
+		m := swiss.NewMap[string, []byte](8)
 		for i := 0; i < num; i++ {
-			m.SetEx(strconv.Itoa(i), str, time.Minute)
+			m.Put(strconv.Itoa(i), str)
 		}
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
 			m.Delete(strconv.Itoa(i))
-		}
-	})
-}
-
-func BenchmarkRand(b *testing.B) {
-	b.Run("std", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			rand.Uint64()
-		}
-	})
-
-	b.Run("exp/std", func(b *testing.B) {
-		source := rand2.NewSource(uint64(time.Now().UnixNano()))
-		for i := 0; i < b.N; i++ {
-			source.Uint64()
 		}
 	})
 }

--- a/cache_bench_test.go
+++ b/cache_bench_test.go
@@ -27,14 +27,14 @@ func BenchmarkSet(b *testing.B) {
 	})
 
 	b.Run("gigacache", func(b *testing.B) {
-		m := New[string]()
+		m := New()
 		for i := 0; i < b.N; i++ {
 			m.Set(strconv.Itoa(i), str)
 		}
 	})
 
 	b.Run("gigacache/Ex", func(b *testing.B) {
-		m := New[string]()
+		m := New()
 		for i := 0; i < b.N; i++ {
 			m.SetEx(strconv.Itoa(i), str, time.Minute)
 		}
@@ -56,7 +56,7 @@ func BenchmarkGet(b *testing.B) {
 		}
 	})
 
-	m3 := New[string]()
+	m3 := New()
 	for i := 0; i < num; i++ {
 		m3.Set(strconv.Itoa(i), str)
 	}
@@ -66,7 +66,7 @@ func BenchmarkGet(b *testing.B) {
 		}
 	})
 
-	m4 := New[string]()
+	m4 := New()
 	for i := 0; i < num; i++ {
 		m4.SetEx(strconv.Itoa(i), str, time.Minute)
 	}
@@ -88,7 +88,7 @@ func BenchmarkDelete(b *testing.B) {
 	})
 
 	b.Run("gigacache", func(b *testing.B) {
-		m := New[string]()
+		m := New()
 		for i := 0; i < num; i++ {
 			m.Set(strconv.Itoa(i), str)
 		}
@@ -100,7 +100,7 @@ func BenchmarkDelete(b *testing.B) {
 	})
 
 	b.Run("gigacache/Ex", func(b *testing.B) {
-		m := New[string]()
+		m := New()
 		for i := 0; i < num; i++ {
 			m.SetEx(strconv.Itoa(i), str, time.Minute)
 		}

--- a/cache_test.go
+++ b/cache_test.go
@@ -28,7 +28,7 @@ func TestCacheSet(t *testing.T) {
 	t.Run("Set/Get", func(t *testing.T) {
 		assert := assert.New(t)
 
-		m := New[string](100)
+		m := New(100)
 		for i := 0; i < num; i++ {
 			m.Set("foo"+strconv.Itoa(i), []byte(strconv.Itoa(i)))
 		}
@@ -110,7 +110,7 @@ func TestCacheSet(t *testing.T) {
 		assertCacheNil(assert, val, ts, ok)
 
 		{
-			m := New[string](1)
+			m := New(1)
 			// test set inplace
 			m.Set("myInt", 1)
 			assert.Equal(len(m.buckets[0].items), 1)
@@ -123,7 +123,7 @@ func TestCacheSet(t *testing.T) {
 
 	t.Run("Nocopy", func(t *testing.T) {
 		assert := assert.New(t)
-		m := New[string](1)
+		m := New(1)
 
 		// get nocopy
 		m.SetEx("nocopy", []byte{1, 2, 3, 4}, time.Minute)
@@ -141,7 +141,7 @@ func TestCacheSet(t *testing.T) {
 		assert.Equal(ok, true)
 
 		// get copy
-		m = New[string](1)
+		m = New(1)
 		m.SetEx("copy", []byte{1, 2, 3, 4}, time.Minute)
 
 		m.buckets[0].scan(func(k string, val any, i int64) bool {
@@ -157,31 +157,8 @@ func TestCacheSet(t *testing.T) {
 		assert.Equal(ok, true)
 	})
 
-	t.Run("int-generic", func(t *testing.T) {
-		assert := assert.New(t)
-		m := New[int](100)
-		m.Set(100, []byte{1})
-
-		// get exist
-		val, ts, ok := m.Get(100)
-		assert.Equal(val, []byte{1})
-		assert.Equal(ts, int64(0))
-		assert.Equal(ok, true)
-
-		// get not exist
-		val, ts, ok = m.Get(200)
-		assertCacheNil(assert, val, ts, ok)
-
-		// get expired
-		m.SetEx(200, []byte{1, 2, 3}, sec)
-		time.Sleep(sec * 2)
-
-		val, ts, ok = m.Get(200)
-		assertCacheNil(assert, val, ts, ok)
-	})
-
 	t.Run("Stat", func(t *testing.T) {
-		m := New[string](20)
+		m := New(20)
 		for i := 0; i < 600; i++ {
 			m.Set(strconv.Itoa(i), str)
 		}
@@ -191,7 +168,7 @@ func TestCacheSet(t *testing.T) {
 		}
 
 		s := m.Stat()
-		if s.LenBytes != 6000 || s.Len != 800 || s.Alloc != 1000 || s.LenAny != 400 {
+		if s.LenBytes != 7690 || s.Len != 800 || s.Alloc != 1000 || s.LenAny != 400 {
 			t.Fatalf("%+v", s)
 		}
 		if s.ExpRate() != 80 {
@@ -200,7 +177,7 @@ func TestCacheSet(t *testing.T) {
 	})
 
 	t.Run("Keys", func(t *testing.T) {
-		m := New[string](20)
+		m := New(20)
 		for i := 0; i < 200; i++ {
 			m.Set("noexp"+strconv.Itoa(i), str)
 			m.SetEx(strconv.Itoa(i), str, sec)
@@ -223,7 +200,7 @@ func TestCacheSet(t *testing.T) {
 	})
 
 	t.Run("RandomGet", func(t *testing.T) {
-		m := New[string](10)
+		m := New(10)
 		m.RandomGet()
 
 		for i := 0; i < 100; i++ {
@@ -249,7 +226,7 @@ func TestCacheSet(t *testing.T) {
 
 	t.Run("Scan", func(t *testing.T) {
 		assert := assert.New(t)
-		m := New[string](20)
+		m := New(20)
 
 		for i := 0; i < 1000; i++ {
 			m.Set("a"+strconv.Itoa(i), []byte(strconv.Itoa(i)))
@@ -298,7 +275,7 @@ func TestCacheSet(t *testing.T) {
 	})
 
 	t.Run("Migrate-small", func(t *testing.T) {
-		m := New[string]()
+		m := New()
 		m.buckets[0].eliminate()
 
 		for i := 0; i < 50; i++ {
@@ -310,7 +287,7 @@ func TestCacheSet(t *testing.T) {
 
 		// check
 		s := m.Stat()
-		if s.LenBytes != 300 || s.Len != 100 || s.Alloc != 100 {
+		if s.LenBytes != 1280 || s.Len != 100 || s.Alloc != 100 {
 			t.Fatalf("%+v", s)
 		}
 
@@ -322,13 +299,13 @@ func TestCacheSet(t *testing.T) {
 
 		// check2
 		s = m.Stat()
-		if s.LenBytes != 300 || s.Len != 101 {
+		if s.LenBytes != 1293 || s.Len != 101 {
 			t.Fatalf("%+v", s)
 		}
 	})
 
 	t.Run("Migrate", func(t *testing.T) {
-		m := New[string]()
+		m := New()
 		m.buckets[0].eliminate()
 
 		for i := 0; i < 100; i++ {
@@ -346,7 +323,7 @@ func TestCacheSet(t *testing.T) {
 
 		// check
 		s := m.Stat()
-		if s.LenBytes != 900 || s.Len != 1000 || s.Alloc != 1000 || s.LenAny != 700 {
+		if s.LenBytes != 3880 || s.Len != 1000 || s.Alloc != 1000 || s.LenAny != 700 {
 			t.Fatalf("%+v", s)
 		}
 
@@ -355,7 +332,7 @@ func TestCacheSet(t *testing.T) {
 
 		// check2
 		s = m.Stat()
-		if s.LenBytes != 300 || s.Len != 400 || s.Alloc != 400 || s.LenAny != 300 {
+		if s.LenBytes != 1390 || s.Len != 400 || s.Alloc != 400 || s.LenAny != 300 {
 			t.Fatalf("%+v", s)
 		}
 
@@ -370,7 +347,7 @@ func TestCacheSet(t *testing.T) {
 
 	t.Run("marshal", func(t *testing.T) {
 		assert := assert.New(t)
-		m := New[string]()
+		m := New()
 
 		for i := 0; i < num; i++ {
 			key := strconv.Itoa(i)
@@ -392,7 +369,7 @@ func TestCacheSet(t *testing.T) {
 		src, err := m.MarshalBytes()
 		assert.Nil(err)
 
-		m1 := New[string]()
+		m1 := New()
 		assert.Nil(m1.UnmarshalBytes(src))
 
 		// unmarshal error
@@ -400,7 +377,7 @@ func TestCacheSet(t *testing.T) {
 	})
 
 	t.Run("eliminate", func(t *testing.T) {
-		m := New[string](100)
+		m := New(100)
 		for i := 0; i < 1000; i++ {
 			m.SetEx(strconv.Itoa(i), i, sec)
 		}
@@ -419,7 +396,7 @@ func TestCacheSet(t *testing.T) {
 }
 
 func FuzzSet(f *testing.F) {
-	m := New[string]()
+	m := New()
 
 	f.Fuzz(func(t *testing.T, key string, val []byte, ts int64) {
 		f := func(ts int64) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -310,7 +310,7 @@ func TestCacheSet(t *testing.T) {
 
 		// check
 		s := m.Stat()
-		if s.LenBytes != 700 || s.Len != 100 || s.Alloc != 100 {
+		if s.LenBytes != 300 || s.Len != 100 || s.Alloc != 100 {
 			t.Fatalf("%+v", s)
 		}
 
@@ -322,7 +322,7 @@ func TestCacheSet(t *testing.T) {
 
 		// check2
 		s = m.Stat()
-		if s.LenBytes != 700 || s.Len != 101 {
+		if s.LenBytes != 300 || s.Len != 101 {
 			t.Fatalf("%+v", s)
 		}
 	})
@@ -346,7 +346,7 @@ func TestCacheSet(t *testing.T) {
 
 		// check
 		s := m.Stat()
-		if s.LenBytes != 2500 || s.Len != 1000 || s.Alloc != 1000 || s.LenAny != 700 {
+		if s.LenBytes != 900 || s.Len != 1000 || s.Alloc != 1000 || s.LenAny != 700 {
 			t.Fatalf("%+v", s)
 		}
 

--- a/example/main.go
+++ b/example/main.go
@@ -44,7 +44,7 @@ func main() {
 	var avgRate, avgBytes, avgTime float64
 	var memStats runtime.MemStats
 
-	bc := cache.New[string]()
+	bc := cache.New()
 
 	// Stat
 	go func() {

--- a/example/main.go
+++ b/example/main.go
@@ -102,14 +102,14 @@ func main() {
 	}
 
 	// Marshal test
-	go func() {
-		for {
-			time.Sleep(time.Second * 8)
-			a := time.Now()
-			bc.MarshalBytes()
-			fmt.Println("Marshal cost:", time.Since(a))
-		}
-	}()
+	// go func() {
+	// 	for {
+	// 		time.Sleep(time.Second * 8)
+	// 		a := time.Now()
+	// 		bc.MarshalBytes()
+	// 		fmt.Println("Marshal cost:", time.Since(a))
+	// 	}
+	// }()
 
 	select {}
 }

--- a/gc/main.go
+++ b/gc/main.go
@@ -75,7 +75,7 @@ func stdMap(entries, valueSize int) {
 }
 
 func gigaCache(entries, valueSize int) {
-	c := cache.New[string]()
+	c := cache.New()
 	for i := 0; i < entries; i++ {
 		key, val := generateKeyValue(i, valueSize)
 		c.SetEx(key, val, time.Minute)

--- a/gc/main.go
+++ b/gc/main.go
@@ -75,10 +75,10 @@ func stdMap(entries, valueSize int) {
 }
 
 func gigaCache(entries, valueSize int) {
-	c := cache.New[string](256)
+	c := cache.New[string]()
 	for i := 0; i < entries; i++ {
 		key, val := generateKeyValue(i, valueSize)
-		c.Set(key, val)
+		c.SetEx(key, val, time.Minute)
 	}
 }
 

--- a/index.go
+++ b/index.go
@@ -5,46 +5,38 @@ import (
 )
 
 // Idx is the index of GigaCahce.
-// hasTTL(1)|isAny(1)|start(31)|offset(31)
+// isAny(1)|start(31)|offset(32)
 
 type Idx uint64
 
 const (
-	offsetMask = math.MaxUint32 >> 1
+	startMask  = math.MaxUint32 >> 1
+	offsetMask = math.MaxUint32
 
-	ttlMask = 1 << 63
-	anyMask = 1 << 62
+	anyMask = 1 << 63
 )
 
 func (i Idx) start() int {
-	return int(i << 2 >> 2 >> 31)
+	return int(i << 1 >> 1 >> 32)
 }
 
 func (i Idx) offset() int {
 	return int(i & offsetMask)
 }
 
-func (i Idx) hasTTL() bool {
-	return i&ttlMask == ttlMask
-}
-
 func (i Idx) IsAny() bool {
 	return i&anyMask == anyMask
 }
 
-func newIdx(start, offset int, hasTTL bool, isAny bool) Idx {
-	// bound check
-	if start > offsetMask {
+func newIdx(start, offset int, isAny bool) Idx {
+	if start > startMask {
 		panic("start overflow")
 	}
 	if offset > offsetMask {
 		panic("offset overflow")
 	}
 
-	idx := Idx(start<<31 | offset)
-	if hasTTL {
-		idx |= ttlMask
-	}
+	idx := Idx(start<<32 | offset)
 	if isAny {
 		idx |= anyMask
 	}

--- a/index_test.go
+++ b/index_test.go
@@ -10,7 +10,7 @@ func TestIndex(t *testing.T) {
 	t.Run("index", func(t *testing.T) {
 		for i := 0; i < 1e8; i++ {
 			a, b := int(rand.Uint32()>>1), int(rand.Uint32()>>1)
-			idx := newIdx(a, b, i%2 == 0, false)
+			idx := newIdx(a, b, i%2 == 0)
 
 			if idx.start() != a {
 				t.Fatalf("%v != %v", idx.start(), a)
@@ -20,11 +20,11 @@ func TestIndex(t *testing.T) {
 			}
 
 			if i%2 == 0 {
-				if !idx.hasTTL() {
+				if !idx.IsAny() {
 					t.Fatal("a")
 				}
 			} else {
-				if idx.hasTTL() {
+				if idx.IsAny() {
 					t.Fatal("b")
 				}
 			}
@@ -37,7 +37,7 @@ func TestIndex(t *testing.T) {
 				t.Fatal("should panic")
 			}
 		}()
-		newIdx(math.MaxInt, 0, false, false)
+		newIdx(math.MaxInt, 0, false)
 	})
 
 	t.Run("panic-offset", func(t *testing.T) {
@@ -46,6 +46,6 @@ func TestIndex(t *testing.T) {
 				t.Fatal("should panic")
 			}
 		}()
-		newIdx(0, math.MaxInt, false, false)
+		newIdx(0, math.MaxInt, false)
 	})
 }


### PR DESCRIPTION
1. use map[uint64]uint64 instead of map[string]uint64 for indexing
2. store the key string in the bytes array